### PR TITLE
Fix wrong color on Discussions Q/A

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
     "name": "GitHub Red Issues",
     "author": "Katsute",
     "description": "Revert closed GitHub issues from purple back to red.",
-    "version": "7.0",
+    "version": "7.1",
     "homepage_url": "https://github.com/KatsuteDev/GitHub-Red-Issues",
     "icons": {
         "16": "icon16.png",

--- a/src/style.css
+++ b/src/style.css
@@ -25,7 +25,7 @@
 
 }
 
-:not(projects-v2 figure) > :not(span.State--merged):not(.TimelineItem-badge) > :is(
+:not(projects-v2 figure) > :not(span.State--merged):not(.TimelineItem-badge):not(a[href*="/discussions"]) > :is(
     /* issue icon */
     svg.octicon-issue-closed,
     /* project icon */


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### Code Generators
*The use of GitHub Copilot or ChatGPT is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot or ChatGPT.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Fix discussions under QA category having a color

was:

![image](https://github.com/KatsuteDev/GitHub-Red-Issues/assets/58778985/254f6af9-99b4-4cee-9184-9bf76e1aa3f7)

fixed:

![image](https://github.com/KatsuteDev/GitHub-Red-Issues/assets/58778985/430ff1f2-fbec-432c-a0a8-0845fec8677e)
